### PR TITLE
LinkedZooming

### DIFF
--- a/DataExtractor/DataExtractor.csproj
+++ b/DataExtractor/DataExtractor.csproj
@@ -84,6 +84,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="BufferedReader.cs" />
+    <Compile Include="PlotRangeChangeEventArgs.cs" />
     <Compile Include="XlsxReader.cs" />
     <Compile Include="XlsxTool.cs" />
     <Compile Include="PlotWindow.xaml.cs">

--- a/DataExtractor/PlotRangeChangeEventArgs.cs
+++ b/DataExtractor/PlotRangeChangeEventArgs.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataExtractor
+{
+    /// <summary>
+    /// Contains the nwe start datetime and end datetime for the plot range changed event.
+    /// </summary>
+    public class PlotRangeChangedEventArgs : EventArgs
+    {
+        public PlotRangeChangedEventArgs(DateTime startDateTime, DateTime endDateTime, PlotWindow initialSource)
+        {
+            StartDateTime = startDateTime;
+            EndDateTime = endDateTime;
+            InitialSource = initialSource;
+        }
+
+        public DateTime StartDateTime, EndDateTime;
+        public PlotWindow InitialSource;
+        
+    }
+}

--- a/DataExtractor/PlotWindow.xaml
+++ b/DataExtractor/PlotWindow.xaml
@@ -113,24 +113,22 @@
                     </Style>
                 </ToggleButton.Style>
             </ToggleButton>
-
-            <StackPanel Grid.Column="3" Grid.RowSpan="3" Margin="5,0">
-                <StackPanel.Style>
-                    <Style TargetType="StackPanel">
+            <ScrollViewer Grid.Column="3" Grid.RowSpan="3" Margin="5,0" VerticalScrollBarVisibility="Auto">
+                <ScrollViewer.Style>
+                    <Style TargetType="ScrollViewer">
                         <Setter Property="Visibility" Value="Visible"/>
                         <Setter Property="IsEnabled" Value="True"/>
                         <Setter Property="Width" Value="Auto"/>
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding ElementName=settingButton, Path=IsChecked}" Value="False">
-
                                 <Setter Property="Visibility" Value="Hidden"/>
                                 <Setter Property="IsEnabled" Value="False"/>
                                 <Setter Property="Width" Value="0"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </StackPanel.Style>
-                <Grid>
+                </ScrollViewer.Style>
+                <Grid Margin="0,0,5,0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -163,27 +161,27 @@
                     <Label Grid.Row="6" Grid.ColumnSpan="3">X Axis Range</Label>
                     <Label Grid.Row="7" Margin="10,0,0,0">From</Label>
                     <TextBox x:Name="xAxisMinnput" Grid.Row="7" Grid.Column="1" Margin="0,2"
-                         Text="{Binding StartDateTime, Converter={StaticResource StrDateTimeConverter}}" Width="120"/>
+                            Text="{Binding StartDateTime, Converter={StaticResource StrDateTimeConverter}}" Width="120"/>
                     <Button x:Name="xAxisMinReset" Grid.Row="7" Grid.Column="2" Margin="5,5,0,5" Click="XAxisMinReset_Click">Reset</Button>
                     <Label Grid.Row="8" Margin="10,0,0,0">To</Label>
                     <TextBox x:Name="xAxisMaxInput" Grid.Row="8" Grid.Column="1" Margin="0,2"
-                         Text="{Binding EndDateTime, Converter={StaticResource StrDateTimeConverter}}"></TextBox>
+                            Text="{Binding EndDateTime, Converter={StaticResource StrDateTimeConverter}}"></TextBox>
                     <Button x:Name="xAxisMaxReset" Grid.Row="8" Grid.Column="2" Margin="5,5,0,5" Click="XAxisMaxReset_Click">Reset</Button>
                     <Label Grid.Row="9" Grid.ColumnSpan="3">Y Axis Range</Label>
                     <Label Grid.Row="10" Margin="10,0,0,0">From</Label>
                     <TextBox x:Name="yAxisMinnput" Grid.Row="10" Grid.Column="1" Margin="0,2"
-                         Text="{Binding YMin, Converter={StaticResource StrDoubleConverter}}" />
+                            Text="{Binding YMin, Converter={StaticResource StrDoubleConverter}}" />
                     <Button x:Name="yAxisMinReset" Grid.Row="10" Grid.Column="2" Margin="5,5,0,5" Click="YAxisMinReset_Click">Reset</Button>
                     <Label Grid.Row="11" Margin="10,0,0,0">To</Label>
                     <TextBox x:Name="yAxisMaxInput" Grid.Row="11" Grid.Column="1" Margin="0,2" 
-                         Text="{Binding YMax, Converter={StaticResource StrDoubleConverter}}"></TextBox>
+                            Text="{Binding YMax, Converter={StaticResource StrDoubleConverter}}"></TextBox>
                     <Button x:Name="yAxisMaxReset" Grid.Row="11" Grid.Column="2" Margin="5,5,0,5" Click="YAxisMaxReset_Click">Reset</Button>
                     <Label Grid.Row="12">Resolution</Label>
                     <TextBox x:Name="resolutionInput" Grid.Row="12" Grid.Column="1" Margin="0,2" Text="{Binding Resolution}"></TextBox>
-                    <Button x:Name="exportButton" Grid.Row="13" Grid.Column="2" Margin="5,5,0,5" Click="ExportButton_Click">Export</Button>
-
+                    <CheckBox x:Name="SyncZoomCheckBox" Grid.Row="13" Grid.ColumnSpan="3" IsChecked="{Binding SyncZoom, Mode=TwoWay}">Synchronize Zooming</CheckBox>
+                    <Button x:Name="exportButton" Grid.Row="14" Grid.Column="2" Margin="5,5,0,5" Click="ExportButton_Click">Export</Button>
                 </Grid>
-            </StackPanel>
+            </ScrollViewer>
 
         </Grid>
     </DockPanel>


### PR DESCRIPTION
Linked Zooming completed. The linked plot windows will change range at the same time. Added a checkbox in PlotWindow to set SyncZoom, which enables a PlotRangeChanged event to be raised when range changed. MainWindow subscribes this event and raise it again, which is subscribed by all PlotWindows.